### PR TITLE
Improve test coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ addopts =
     --no-cov-on-fail
     --cov=schvalidator
     --cov-report=term-missing
-    --showlocals
+    # --showlocals

--- a/src/schvalidator/__init__.py
+++ b/src/schvalidator/__init__.py
@@ -58,10 +58,12 @@ def main(cliargs=None):
         log.fatal(error)
         sys.exit(10)
 
-    except (etree.XMLSyntaxError, etree.XSLTApplyError) as error:
-        log.fatal(error, exc_info=error, stack_info=True)
+    except (etree.XMLSyntaxError,
+            etree.XSLTApplyError,
+            etree.SchematronParseError) as error:
+        log.fatal(error) # exc_info=error,
         sys.exit(20)
 
     except (FileNotFoundError, OSError) as error:
-        log.fatal(error, exc_info=error, stack_info=True)
+        log.fatal(error)
         sys.exit(30)

--- a/src/schvalidator/__init__.py
+++ b/src/schvalidator/__init__.py
@@ -61,7 +61,7 @@ def main(cliargs=None):
     except (etree.XMLSyntaxError,
             etree.XSLTApplyError,
             etree.SchematronParseError) as error:
-        log.fatal(error) # exc_info=error,
+        log.fatal(error)  # exc_info=error,
         sys.exit(20)
 
     except (FileNotFoundError, OSError) as error:

--- a/src/schvalidator/schematron.py
+++ b/src/schvalidator/schematron.py
@@ -75,13 +75,6 @@ def validate_sch(schema, xmlfile, phase=None, xmlparser=None):
     return result, schematron
 
 
-def check_args(args):
-    """Checks the arguments for consistency"""
-    for f in [args['XMLFILE'], args['--schema']]:
-        if not os.path.exists(f):
-            raise ProjectFilesNotFoundError("File not found", f)
-
-
 def extractrole(fa):
     """Try to extract ``role`` attributes either in the ``svrl:failed-assert''
        or in the preceding sibling ``svrl:fired-rule`` element.
@@ -127,7 +120,6 @@ def process_result_svrl(report):
 def process(args):
     """Process the validation and the result
     """
-    check_args(args)
     result, schematron = validate_sch(args['--schema'],
                                       args['XMLFILE'],
                                       phase=args['--phase'],

--- a/tests/test_filenotfound.py
+++ b/tests/test_filenotfound.py
@@ -1,34 +1,17 @@
 
 import pytest
-import os.path
-from schvalidator.schematron import check_args, process
+import schvalidator.schematron as schematron
 from schvalidator.exceptions import ProjectFilesNotFoundError
-
-
-@pytest.mark.parametrize('schema,xmlfile', [
-    (None, 'file-does-not-exist.xml'),
-    ('schema-does-not-exist.sch', None),
-])
-def test_check_args(monkeypatch, schema, xmlfile):
-    args = {'--schema': schema,
-            'XMLFILE': xmlfile}
-    def mockreturn(filename):
-        return filename is None
-
-    monkeypatch.setattr(os.path,
-                        'exists',
-                        mockreturn)
-    with pytest.raises(ProjectFilesNotFoundError):
-        check_args(args)
 
 
 def test_filenotfound1():
     #
     args = {'--schema': 'schema-does-not-exist.sch',
+            '--phase': None,
             'XMLFILE': 'file-does-not-exist.xml'}
 
     with pytest.raises((FileNotFoundError, OSError)):
-        process(args)
+        schematron.process(args)
 
 
 def test_filenotfound2():

--- a/tests/test_schvalidator.py
+++ b/tests/test_schvalidator.py
@@ -37,7 +37,6 @@ def test_main(capsys):
     ("schema.sch", None),
 ])
 def test_main_with_exception(monkeypatch, schema, xmlfile):
-
     # Patching etree.parse
     monkeypatch.setattr('schvalidator.cli.parsecli',
                         {'--schema': schema, 'XMLFILE': xmlfile})


### PR DESCRIPTION
* Disable --showlocals in setup.cfg
* Catch also etree.SchematronParseError
* Remove exc_info=error, stack_info=True arguments in log.fatal()
* Remove check_args() in schematron.py
* Remove code in tests which calls check_args()
* Add new testcase test_validate_sch
* Improve test coverage for test_cli.py