### PR TITLE
Fix #16: implement Schematron check

### DIFF
--- a/src/schvalidator/cli.py
+++ b/src/schvalidator/cli.py
@@ -42,8 +42,13 @@ import logging
 from logging.config import dictConfig
 from lxml import etree
 
-from .common import DEFAULT_LOGGING_DICT, ERROR_CODES, LOGLEVELS, LOGNAMES
-from .exceptions import ProjectFilesNotFoundError
+from .common import (DEFAULT_LOGGING_DICT,
+                     ERROR_CODES, LOGLEVELS, LOGNAMES
+                     )
+from .exceptions import (NoISOSchematronFileError,
+                         OldSchematronError,
+                         ProjectFilesNotFoundError,
+                         )
 from .schematron import process
 
 #: Use __package__, not __name__ here to set overall logging level:
@@ -111,5 +116,10 @@ def main(cliargs=None):
         return ERROR_CODES.get(type(error), 255)
 
     except (FileNotFoundError, OSError) as error:
+        log.fatal(error)
+        return ERROR_CODES.get(repr(type(error)), 255)
+
+    except (NoISOSchematronFileError, OldSchematronError) as error:
+        # print(repr(error))
         log.fatal(error)
         return ERROR_CODES.get(repr(type(error)), 255)

--- a/src/schvalidator/cli.py
+++ b/src/schvalidator/cli.py
@@ -43,7 +43,7 @@ from logging.config import dictConfig
 from lxml import etree
 
 from .common import (DEFAULT_LOGGING_DICT,
-                     ERROR_CODES, LOGLEVELS, LOGNAMES
+                     errorcode, LOGLEVELS, LOGNAMES
                      )
 from .exceptions import (NoISOSchematronFileError,
                          OldSchematronError,
@@ -98,28 +98,28 @@ def main(cliargs=None):
 
     except (ProjectFilesNotFoundError) as error:
         log.fatal(error)
-        return ERROR_CODES.get(repr(type(error)), 255)
+        return errorcode(error)
 
     except (etree.XMLSyntaxError,
             etree.XSLTApplyError,
             etree.SchematronParseError) as error:
         log.fatal(error)
-        return ERROR_CODES.get(repr(type(error)), 255)
+        return errorcode(error)
 
     # except etree.SchematronParseError as error:
     #    log.fatal("Schematron file %r error", args['SCHEMA'])
     #    log.fatal(error)
-    #    return ERROR_CODES.get(repr(type(error)), 255)
+    #    return errorcode(error)
 
     except etree.XSLTParseError as error:
         log.fatal(error.error_log)
-        return ERROR_CODES.get(type(error), 255)
+        return errorcode(error)
 
     except (FileNotFoundError, OSError) as error:
         log.fatal(error)
-        return ERROR_CODES.get(repr(type(error)), 255)
+        return errorcode(error)
 
     except (NoISOSchematronFileError, OldSchematronError) as error:
         # print(repr(error))
         log.fatal(error)
-        return ERROR_CODES.get(repr(type(error)), 255)
+        return errorcode(error)

--- a/src/schvalidator/cli.py
+++ b/src/schvalidator/cli.py
@@ -43,7 +43,7 @@ from logging.config import dictConfig
 from lxml import etree
 
 from .common import (DEFAULT_LOGGING_DICT,
-                     errorcode, LOGLEVELS, LOGNAMES
+                     errorcode, LOGLEVELS,
                      )
 from .exceptions import (NoISOSchematronFileError,
                          OldSchematronError,

--- a/src/schvalidator/common.py
+++ b/src/schvalidator/common.py
@@ -16,7 +16,10 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
-from .exceptions import ProjectFilesNotFoundError
+from .exceptions import (NoISOSchematronFileError,
+                         OldSchematronError,
+                         ProjectFilesNotFoundError,
+                         )
 from logging import (BASIC_FORMAT,
                      CRITICAL,
                      DEBUG,
@@ -27,14 +30,20 @@ from logging import (BASIC_FORMAT,
                      WARN,
                      WARNING,
                      )
-from lxml.etree import (SchematronParseError,
+from lxml.etree import (QName,
+                        SchematronParseError,
                         XMLSyntaxError,
                         XSLTApplyError,
                         XSLTParseError,
                         )
 
 
-__all__ = ['ERROR_CODES']
+__all__ = ['DEFAULT_LOGGING_DICT',
+           'ERROR_CODES',
+           'LOGLEVELS', 'LOGNAMES',
+           'NSMAP',
+           'SCHEMA_TAG',
+           ]
 
 
 # Error codes
@@ -48,9 +57,27 @@ for _error, _rc in [(ProjectFilesNotFoundError, 10),
                     (XSLTParseError, 30),
                     (FileNotFoundError, 40),
                     (OSError, 40),
+                    (NoISOSchematronFileError, 50),
+                    (OldSchematronError, 51),
                     ]:
     ERROR_CODES[_error] = _rc
     ERROR_CODES[repr(_error)] = _rc
+
+
+#: Prefix to namespace mappings
+NSMAP = dict(db="http://docbook.org/ns/docbook",
+             # Schematron namespace
+             s="http://purl.oclc.org/dsdl/schematron",
+             # Obsolete, deprecated namespace of old Schematron
+             oldsch="http://www.ascc.net/xml/schematron",
+             # Schematron Validation Report namespace
+             svrl="http://purl.oclc.org/dsdl/svrl",
+             # XML Schema namespace
+             xs="http://www.w3.org/2001/XMLSchema",
+             )
+
+SCHEMA_TAG = QName(NSMAP['s'], 'schema')
+OLD_SCHEMA_TAG = QName(NSMAP['oldsch'], 'schema')
 
 
 #: Map verbosity to log levels

--- a/src/schvalidator/common.py
+++ b/src/schvalidator/common.py
@@ -64,6 +64,16 @@ for _error, _rc in [(ProjectFilesNotFoundError, 10),
     ERROR_CODES[repr(_error)] = _rc
 
 
+def errorcode(error):
+    """Get the error exit code from an exception ``error``
+
+    :param error: exception instance
+    :return: exit code
+    :rtype: int
+    """
+    return ERROR_CODES.get(repr(type(error)), 255)
+
+
 #: Prefix to namespace mappings
 NSMAP = dict(db="http://docbook.org/ns/docbook",
              # Schematron namespace

--- a/src/schvalidator/exceptions.py
+++ b/src/schvalidator/exceptions.py
@@ -16,9 +16,23 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
+"""Exception classes"""
+
 
 class ProjectFilesNotFoundError(FileNotFoundError):
     def __repr__(self):
         # print("ProjectFilesNotFoundError:", self.args)
         # return "%s %s" % (self.args[0], self.args[1])
         return "%s - %s" % (self.strerror, self.args[1])
+
+
+class BaseSchematronError(Exception):
+    pass
+
+
+class NoISOSchematronFileError(BaseSchematronError):
+    pass
+
+
+class OldSchematronError(BaseSchematronError):
+    pass

--- a/tests/data/old-schematron.sch
+++ b/tests/data/old-schematron.sch
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.ascc.net/xml/schematron"/>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,10 @@ from unittest.mock import patch
 import schvalidator
 from schvalidator.cli import parsecli
 from schvalidator.common import ERROR_CODES
-from schvalidator.exceptions import ProjectFilesNotFoundError
+from schvalidator.exceptions import (NoISOSchematronFileError,
+                                     OldSchematronError,
+                                     ProjectFilesNotFoundError,
+                                     )
 
 TESTDIR = py.path.local(__file__).dirpath()
 DATADIR = TESTDIR / "data"
@@ -141,3 +144,34 @@ def test_main_raise_OSError(monkeypatch, excpt):
 
     result = schvalidator.cli.main()
     assert result == ERROR_CODES[excpt]
+
+
+
+def test_oldschematron(monkeypatch):
+
+    def _parsecli(cliargs=None):
+        return {'SCHEMA': str(DATADIR / "old-schematron.sch"),
+                'XMLFILE': str(DATADIR / "article-001.xml"),
+                '--phase': None,
+                }
+    monkeypatch.setattr(schvalidator.cli,
+                        'parsecli',
+                        _parsecli)
+
+    result = schvalidator.cli.main()
+    assert result == ERROR_CODES[OldSchematronError]
+
+
+def test_isoschematron(monkeypatch):
+
+    def _parsecli(cliargs=None):
+        return {'SCHEMA': str(DATADIR / "article-001.xml"),
+                'XMLFILE': str(DATADIR / "article-001.xml"),
+                '--phase': None,
+                }
+    monkeypatch.setattr(schvalidator.cli,
+                        'parsecli',
+                        _parsecli)
+
+    result = schvalidator.cli.main()
+    assert result == ERROR_CODES[NoISOSchematronFileError]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ from unittest.mock import patch
 
 import schvalidator
 from schvalidator.cli import parsecli
-from schvalidator.common import ERROR_CODES
+from schvalidator.common import ERROR_CODES, errorcode
 from schvalidator.exceptions import (NoISOSchematronFileError,
                                      OldSchematronError,
                                      ProjectFilesNotFoundError,
@@ -32,6 +32,15 @@ from schvalidator.exceptions import (NoISOSchematronFileError,
 
 TESTDIR = py.path.local(__file__).dirpath()
 DATADIR = TESTDIR / "data"
+
+
+def test_errorcode():
+    for error in ERROR_CODES:
+        assert errorcode(error)
+
+
+def test_invalid_errorcode():
+    assert errorcode(ArithmeticError) == 255
 
 
 @pytest.mark.parametrize('cli,expected', [

--- a/tests/test_schematron.py
+++ b/tests/test_schematron.py
@@ -24,10 +24,11 @@ import sys
 from unittest.mock import Mock
 
 import schvalidator.schematron
-from schvalidator.schematron import (NS, NSElement,
+from schvalidator.schematron import (NSElement,
                                      extractrole,
                                      process, process_result_svrl,
                                      svrl, validate_sch)
+from schvalidator.common import NSMAP
 
 
 def test_NSElement():
@@ -138,6 +139,7 @@ def test_process_result_svrl(caplog):
         assert record.funcName == process_result_svrl.__name__
 
 
+# @pytest.mark.skip
 @pytest.mark.parametrize('xmlparser', [
     None, "xmlparser"
 ])
@@ -157,6 +159,10 @@ def test_validate_sch(monkeypatch, xmlparser):
     monkeypatch.setattr(schvalidator.schematron,
                         'Schematron',
                         mock_schematron)
+    monkeypatch.setattr(schvalidator.schematron,
+                        'check4schematron',
+                        lambda x, y: None
+                        )
     result, schematron = validate_sch("fake.sch",
                                       "fake.xml",
                                       xmlparser=xmlparser)

--- a/tests/test_validation-cases.py
+++ b/tests/test_validation-cases.py
@@ -22,7 +22,8 @@ from lxml import etree
 import pytest
 import sys
 
-from schvalidator.schematron import NS, validate_sch
+from schvalidator.schematron import validate_sch
+from schvalidator.common import NSMAP
 
 
 def test_validation(schtestcase):
@@ -39,6 +40,6 @@ def test_validation(schtestcase):
                  "//svrl:failed-assert/@role",
                  ]
     for expr in xpathexpr:
-        expected = svrltree.xpath(expr, namespaces=NS)
-        result = report.xpath(expr, namespaces=NS)
+        expected = svrltree.xpath(expr, namespaces=NSMAP)
+        result = report.xpath(expr, namespaces=NSMAP)
         assert expected == result


### PR DESCRIPTION
* Introduce check4schematron() to check if it is an old or new (ISO)
  Schematron schema
* Adapt testcases
* Move namespace dict into `common.py`
* Introduce new exception errors: `NoISOSchematronFileError` and `OldSchematronError`. Both are derived from `BaseSchematronError`
* Introduce function `errorcode()`
  * Should reduce code similarities
  * Add testcase for `errorcode()`