### PR TITLE
Store validation XSLT tree into a file

### DIFF
--- a/src/schvalidator/cli.py
+++ b/src/schvalidator/cli.py
@@ -27,6 +27,8 @@ Options:
     -h, --help      Shows this help
     -v              Raise verbosity level
     --version       Prints the version
+    --store-xslt XSLTFILE
+                    save the validation XSLT tree to XSLTFILE
     --report REPORTFILE
                     save output of Schematron validation to REPORTFILE
     --phase PHASE   a validation phase

--- a/src/schvalidator/schematron.py
+++ b/src/schvalidator/schematron.py
@@ -155,17 +155,13 @@ def process_result_svrl(report):
                 idx, loc, text, "-" * 20)
 
 
-def process(args):
-    """Process the validation and the result
+def save_reportfile(schematron, args):
+    """Save the report file from the --report option
 
+    :param schematron: the Schematron object
+    :type schematron: :class:`lxml.isoschematron.Schematron`
     :param dict args: Dictionary of parsed CLI arguments
-    :return: return exit value
-    :rtype: int
     """
-    result, schematron = validate_sch(args['SCHEMA'],
-                                      args['XMLFILE'],
-                                      phase=args['--phase'],
-                                      )
     reportfile = args['--report']
 
     if reportfile is not None:
@@ -177,7 +173,14 @@ def process(args):
     else:
         log.debug(schematron.validation_report)
 
-    #
+
+def save_xsltfile(schematron, args):
+    """Save the validation XSLT tree from the --store-xslt option
+
+    :param schematron: the Schematron object
+    :type schematron: :class:`lxml.isoschematron.Schematron`
+    :param dict args: Dictionary of parsed CLI arguments
+    """
     xsltfile = args['--store-xslt']
     if xsltfile is not None:
         schematron.validator_xslt.write(xsltfile,
@@ -186,6 +189,20 @@ def process(args):
                                         )
         log.info("Wrote validation XSLT file to %r", xsltfile)
 
+
+def process(args):
+    """Process the validation and the result
+
+    :param dict args: Dictionary of parsed CLI arguments
+    :return: return exit value
+    :rtype: int
+    """
+    result, schematron = validate_sch(args['SCHEMA'],
+                                      args['XMLFILE'],
+                                      phase=args['--phase'],
+                                      )
+    save_reportfile(schematron, args)
+    save_xsltfile(schematron, args)
     process_result_svrl(schematron.validation_report)
 
     if not result:

--- a/src/schvalidator/schematron.py
+++ b/src/schvalidator/schematron.py
@@ -177,6 +177,15 @@ def process(args):
     else:
         log.debug(schematron.validation_report)
 
+    #
+    xsltfile = args['--store-xslt']
+    if xsltfile is not None:
+        schematron.validator_xslt.write(xsltfile,
+                                        pretty_print=True,
+                                        encoding="utf-8",
+                                        )
+        log.info("Wrote validation XSLT file to %r", xsltfile)
+
     process_result_svrl(schematron.validation_report)
 
     if not result:

--- a/tests/schematron.rnc
+++ b/tests/schematron.rnc
@@ -1,0 +1,209 @@
+# Copyright © ISO/IEC 2015
+# The following permission notice and disclaimer shall be included in all
+# copies of this XML schema ("the Schema"), and derivations of the Schema:
+# Permission is hereby granted, free of charge in perpetuity, to any
+# person obtaining a copy of the Schema, to use, copy, modify, merge and
+# distribute free of charge, copies of the Schema for the purposes of
+# developing, implementing, installing and using software based on the
+# Schema, and to permit persons to whom the Schema is furnished to do so,
+# subject to the following conditions:
+# THE SCHEMA IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SCHEMA OR THE USE OR
+# OTHER DEALINGS IN THE SCHEMA.
+# In addition, any modified copy of the Schema shall include the following
+# notice:
+# "THIS SCHEMA HAS BEEN MODIFIED FROM THE SCHEMA DEFINED IN ISO/IEC 19757-3,
+# AND SHOULD NOT BE INTERPRETED AS COMPLYING WITH THAT STANDARD".
+namespace local = ""
+default namespace sch = "http://purl.oclc.org/dsdl/schematron"
+start = schema
+# Element declarations
+schema =
+     element schema {
+          attribute id { xsd:ID }?,
+          rich,
+          attribute schemaVersion { non-empty-string }?,
+          attribute defaultPhase { xsd:IDREF }?,
+          attribute queryBinding { non-empty-string }?,
+          (foreign
+           & inclusion*
+           & (title?, ns*, p*, let*, phase*, pattern+, p*, diagnostics?, properties))
+     }
+active =
+     element active {
+          attribute pattern { xsd:IDREF },
+          (foreign & (text | dir | emph | span)*)
+     }
+assert =
+     element assert {
+          attribute test { exprValue },
+          attribute flag { flagValue }?,
+          attribute id { xsd:ID }?,
+          attribute diagnostics { xsd:IDREFS }?,
+          attribute properties { xsd:IDREFS }?,
+          rich,
+          linkable,
+         (foreign & (text | name | value-of | emph | dir | span)*)
+     }
+diagnostic =
+     element diagnostic {
+         attribute id { xsd:ID },
+         rich,
+         (foreign & (text | value-of | emph | dir | span)*)
+     }
+diagnostics = element diagnostics { foreign & inclusion* & diagnostic* }
+dir =
+     element dir {
+         attribute value { "ltr" | "rtl" }?,
+         (foreign & text)
+     }
+emph = element emph { text }
+extends =
+     element extends {
+         (attribute rule { xsd:IDREF }
+          | attribute href { uriValue }),
+         foreign-empty
+     }
+let =
+     element let {
+         attribute name { nameValue },
+         (attribute value { string }
+          | foreign-element+)
+     }
+name =
+     element name {
+         attribute path { pathValue }?,
+         foreign-empty
+     }
+ns =
+     element ns {
+         attribute uri { uriValue },
+         attribute prefix { nameValue },
+         foreign-empty
+     }
+p =
+     element p {
+         attribute id { xsd:ID }?,
+         attribute class { classValue }?,
+         attribute icon { uriValue }?,
+         (foreign & (text | dir | emph | span)*)
+     }
+param =
+     element param {
+         attribute name { nameValue },
+         attribute value { non-empty-string }
+     }
+pattern =
+     element pattern {
+         attribute documents { pathValue }?,
+         rich,
+         (foreign
+          & inclusion*
+          & ((attribute abstract { "true" },
+               attribute id { xsd:ID },
+               title?,
+               (p*, let*, rule*))
+             | (attribute abstract { "false" }?,
+                 attribute id { xsd:ID }?,
+                 title?,
+                 (p*, let*, rule*))
+             | (attribute abstract { "false" }?,
+                 attribute is-a { xsd:IDREF },
+                 attribute id { xsd:ID }?,
+                 title?,
+                 (p*, param*))))
+     }
+phase =
+     element phase {
+          attribute id { xsd:ID },
+          rich,
+          (foreign & inclusion* & (p*, let*, active*))
+     }
+properties = element properties { property* }
+property =
+     element property {
+          attribute id { xsd:ID },
+          attribute role { roleValue }?,
+          attribute scheme { text }?,
+          (foreign & (text | name | value-of | emph | dir | span)*)
+     }
+report =
+     element report {
+          attribute test { exprValue },
+          attribute flag { flagValue }?,
+          attribute id { xsd:ID }?,
+          attribute diagnostics { xsd:IDREFS }?,
+          attribute properties { xsd:IDREFS }?,
+          rich,
+          linkable,
+          (foreign & (text | name | value-of | emph | dir | span)*)
+     }
+rule =
+     element rule {
+          attribute flag { flagValue }?,
+          rich,
+          linkable,
+          (foreign
+           & inclusion*
+           & ((attribute abstract { "true" },
+                 attribute id { xsd:ID },
+                 let*,
+                 (assert | report | extends | p)+)
+               | (attribute context { pathValue },
+                    attribute id { xsd:ID }?,
+                    attribute abstract { "false" }?,
+                    let*,
+                    (assert | report | extends | p)+)))
+     }
+span =
+     element span {
+          attribute class { classValue },
+          (foreign & text)
+     }
+title = element title { (text | dir)* }
+value-of =
+     element value-of {
+          attribute select { pathValue },
+          foreign-empty
+     }
+# common declarations
+inclusion =
+     element include {
+          attribute href { uriValue },
+          foreign-empty
+     }
+rich =
+     attribute icon { uriValue }?,
+     attribute see { uriValue }?,
+     attribute fpi { fpiValue }?,
+     attribute xml:lang { langValue }?,
+     attribute xml:space { "preserve" | "default" }?
+linkable =
+     attribute role { roleValue }?,
+     attribute subject { pathValue }?
+foreign = foreign-attributes, foreign-element*
+foreign-empty = foreign-attributes
+foreign-attributes = attribute * - (local:* | xml:*) { text }*
+foreign-element =
+     element * - sch:* {
+         (attribute * { text }
+          | foreign-element
+          | schema
+          | text)*
+     }
+# Data types
+uriValue = xsd:anyURI
+pathValue = string
+exprValue = string
+fpiValue = string
+langValue = xsd:language
+roleValue = string
+flagValue = string
+nameValue = string
+# In the default query language binding, xsd:NCNAME
+classValue = string
+non-empty-string = xsd:token { minLength = "1" }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,11 @@ def test_invalid_errorcode():
     'SCHEMA': 'schema.sch',
     'XMLFILE':  'a.xml'}
    ),
+   (['--store-xslt', 'foo.xsl', 'schema.sch', 'a.xml'],
+    {'--store-xslt': 'foo.xsl',
+     'SCHEMA': 'schema.sch',
+     'XMLFILE':  'a.xml'}
+   ),
 ])
 def test_parsecli(cli, expected):
     result = parsecli(cli)


### PR DESCRIPTION
Change in this PR (related issue #20)

* add new option `--store-xslt`
* store the validation XSLT tree into a file